### PR TITLE
[breaking change] Switch goroot and goinstall directories

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -21,9 +21,10 @@ fi
 # Check format
 INITIAL_STATUS="$(git status -s | shasum)"
 go fmt
+make readme
 TERMINAL_STATUS="$(git status -s | shasum)"
 if [[ "${INITIAL_STATUS}" != "${TERMINAL_STATUS}" ]]; then
-    fail "go fmt had to format files. review code and try again"
+    fail "had to format files. review code and try again"
 fi
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
 # Contributing
 
 Pull Requests are welcome! I'd like to keep this project small, simple, and friendly 🥳. The [Makefile](./Makefile) is heavily commented to help lower the barrier to contributions.
+
+Using githooks will make testing much easier. `make githooks` to install them. You'll have to do this everytime you make a new clone of this repo.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,3 @@
 # Contributing
 
 Pull Requests are welcome! I'd like to keep this project small, simple, and friendly 🥳. The [Makefile](./Makefile) is heavily commented to help lower the barrier to contributions.
-
-## How This Works
-
-`goenv` does the following:
-  - Downloads the tarball for the corresponding version a user provides
-  - Extracts the tarball to `/usr/local/goenv/${VERSION}`. For example, `goenv install 1.17.6` will create `/usr/local/goenv/1.17.6`
-  - Creates a symlink from `/usr/local/bin/go/` to `/usr/local/goenv/1.17.6/bin/go`. The same thing happens for `gofmt`.
-
-The install directory `/usr/local/goenv` is configurable through environment variables.
-
-This project resists adding more functionality in an attempt to be simple.
-
-## Other Implementations
-
-There are a few other implementations of this that have more features, but I only needed the binaries. Other implementations can do fancier things like check for the correct Go version and use the corresponding version in runtime, but they require intercepting the call to Go and passing the command to the right version. I didn't want my code to be in the "hot path."
-
-A few other implementations are also written in other languages. This one is written in Go 🥵.
-
-The recommendation on the Go website is to use your first install of Go to install _other_ versions of Go. Then you'd call other versions of Go like `go1.17.8 build`. This provides a consistent experience.

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ release:
 	gh release create --notes "Release ${VERSION}" --target main ${SEMVER} tmp/goenv-*-amd64-${SEMVER}.tar.gz
 
 readme:
-	envsubst < templates/README.md > README.md
+	@sed "s/XXLatestXX/${SEMVER}/g" < templates/README.md > README.md
 
 # Turns on some hooks to check format and build status before commiting/pushing. Optional, but helpful.
 githooks:

--- a/README.md
+++ b/README.md
@@ -4,9 +4,30 @@
 
 goenv is an small, simple binary that executes the [install instructions](https://go.dev/doc/install) on the Go website and manages several Go versions. Goenv downloads and extracts go to `/usr/local/goenv/<VERSION>` and adds a symlink from `/usr/local/go -> /usr/local/goenv/<VERSION>`. It was heavily inspired by [Dave Cheney's blog post](https://dave.cheney.net/2014/04/20/how-to-install-multiple-versions-of-go).
 
+## Install
+
+To install goenv, follow the steps below. Older releases are in the [Releases page](https://github.com/drewgonzales360/goenv/releases).
+
+```bash
+# Step 1: Linux Only
+curl -sSL https://github.com/drewgonzales360/goenv/releases/download/v0.0.3/goenv-linux-amd64-v0.0.3.tar.gz -o /tmp/goenv-v0.0.3.tar.gz
+
+# Step 1: Mac Only
+curl -sSL https://github.com/drewgonzales360/goenv/releases/download/v0.0.3/goenv-darwin-amd64-v0.0.3.tar.gz -o /tmp/goenv-v0.0.3.tar.gz
+
+# Step 2: Extract and Install Go
+tar -xzvf /tmp/goenv-v0.0.3.tar.gz -C /tmp
+mv /tmp/goenv /usr/local/bin
+
+# Step 3: Add /usr/local/go/bin (or $GOENV_ROOT_DIR/bin) to PATH
+export PATH=/usr/local/go/bin:PATH
+```
+
+Install this binary _without_ `go install` so that it is managed independent of Go.
+
 ## Usage
 
-Calling `goenv` without any arguments will print out a helpful block of text, but here are a few useful examples.
+Calling `goenv` without any arguments will print out a helpful block of text, but here are a few useful examples. Note that installing 1.14 will install 1.14, even if 1.14.5 is the latest patch version.
 
 ```bash
 # Install and use a go version
@@ -22,27 +43,6 @@ goenv uninstall 1.16
 goenv list
 ```
 
-## Install
-
-To install goenv, follow the steps below. Older releases are in the Releases page.
-
-```bash
-# Step 1: Linux Only
-curl -sSL https://github.com/drewgonzales360/goenv/releases/download/v0.0.3/goenv-linux-amd64-v0.0.3.tar.gz -o /tmp/goenv-v0.0.3.tar.gz
-
-# Step 1: Mac Only
-curl -sSL https://github.com/drewgonzales360/goenv/releases/download/v0.0.3/goenv-darwin-amd64-v0.0.3.tar.gz -o /tmp/goenv-v0.0.3.tar.gz
-
-# Step 2: Extract and Install Go
-tar -xzvf /tmp/goenv-v0.0.3.tar.gz -C /tmp
-mv /tmp/goenv /usr/local/bin
-
-# Step 3: Add /usr/local/go/bin to PATH or put this line in whichever dotfile is used
-export PATH=/usr/local/go/bin:PATH
-```
-
-It's best to install this binary without `go install` so that it is managed independent of Go.
-
 ## Configuration
 
 | Environment Variable  | Default             | Explanation |
@@ -54,15 +54,32 @@ The default `GOROOT` usually requires root access. You can avoid it by setting t
 
 ```shell
 # goenv configuration
-export GOENV_INSTALL_DIR="/home/drew/.local/goenv"
-export GOENV_ROOT_DIR="/home/drew/.local/go"
-export PATH="/mnt/NRG/usr/local/go/bin:/mnt/NRG/usr/local/goenv/bin:/mnt/NRG/usr/local/go/bin:/mnt/NRG/usr/local/go/bin:/home/drew/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/snap/bin:/home/drew/.fzf/bin:/mnt/NRG/Docs/CS/Code/go/bin:/home/drew/.cargo/bin:/mnt/NRG/Docs/CS/Code/go/bin:/home/drew/.cargo/bin"
+export GOENV_INSTALL_DIR="$HOME/.local/goenv"
+export GOENV_ROOT_DIR="$HOME/.local/go"
+export PATH="$GOENV_ROOT_DIR/bin:$PATH"
 ```
 
 If your VScode editor throws you weird errors on start up, add this to your vscode settings.json.
 ```json
 {
     "go.gopath": "/your/gopath",
-    "go.goroot": "/your/goroot", # or whatever /mnt/NRG/usr/local/go is set to
+    "go.goroot": "/your/goroot", # or whatever $GOENV_ROOT_DIR is set to
 }
 ```
+
+## How This Works
+
+`goenv` does the following by default:
+  - Downloads the tarball for the corresponding version a user provides. Makes a best effort attempt to check the shasums
+  - Extracts the tarball to `/usr/local/goenv/${VERSION}`. For example, `goenv install 1.17.6` will create `/usr/local/goenv/1.17.6`
+  - Creates a symlink from `/usr/local/go/` to `/usr/local/goenv/1.17.6/bin/go`. The same thing happens for `gofmt`.
+
+The install directory `/usr/local/goenv` and root directory `/usr/local/go` is configurable through environment variables.
+
+## Other Implementations
+
+There are a few other implementations of this that have more features, but I only needed the binaries. Other implementations can do fancier things like check for the correct Go version for a module and use the corresponding version in runtime, but they require intercepting the call to Go and passing the command to the right version. I didn't want my code to be in the "hot path."
+
+A few other implementations are also written in other languages. This one is written in Go 🥵.
+
+The recommendation on the Go website is to use your first install of Go to install _other_ versions of Go. Then you'd call other versions of Go like `go1.17.8 build`. This provides a consistent experience.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![github workflow](https://github.com/drewgonzales360/goenv/actions/workflows/github-actions.yml/badge.svg)
 
-goenv is an small, simple binary that executes the [install instructions](https://go.dev/doc/install) on the Go website and manages several Go versions. There are several other implementations that have more features, but this has fewer ones by design. Goenv downloads and extracts go to `/usr/local/goenv/<VERSION>` and adds a symlink from `/usr/local/go -> /usr/local/goenv/<VERSION>`. It doesn't do anything fancy like guess the version of a project, intercept calls to `go`, or check for new versions.
+goenv is an small, simple binary that executes the [install instructions](https://go.dev/doc/install) on the Go website and manages several Go versions. Goenv downloads and extracts go to `/usr/local/goenv/<VERSION>` and adds a symlink from `/usr/local/go -> /usr/local/goenv/<VERSION>`. It was heavily inspired by [Dave Cheney's blog post](https://dave.cheney.net/2014/04/20/how-to-install-multiple-versions-of-go).
 
 ## Usage
 
@@ -47,13 +47,22 @@ It's best to install this binary without `go install` so that it is managed inde
 
 | Environment Variable  | Default             | Explanation |
 | -                     | -                   | - |
-| GOENV_ROOT_DIR        | "/usr/local/go"     | Usually equivalent to your GoRoot. This is should be in your path and links to the GOENV_INSTALL_DIR |
+| GOENV_ROOT_DIR        | "/usr/local/go"     | This is the default Go root. This is should be in your path and links to the GOENV_INSTALL_DIR |
 | GOENV_INSTALL_DIR     | "/usr/local/goenv"  | Directory where your various Go installations will be installed |
+
+The default `GOROOT` usually requires root access. You can avoid it by setting the configuration variables above. Adding
+
+```shell
+# goenv configuration
+export GOENV_INSTALL_DIR="/home/drew/.local/goenv"
+export GOENV_ROOT_DIR="/home/drew/.local/go"
+export PATH="/mnt/NRG/usr/local/go/bin:/mnt/NRG/usr/local/goenv/bin:/mnt/NRG/usr/local/go/bin:/mnt/NRG/usr/local/go/bin:/home/drew/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/snap/bin:/home/drew/.fzf/bin:/mnt/NRG/Docs/CS/Code/go/bin:/home/drew/.cargo/bin:/mnt/NRG/Docs/CS/Code/go/bin:/home/drew/.cargo/bin"
+```
 
 If your VScode editor throws you weird errors on start up, add this to your vscode settings.json.
 ```json
 {
-    "go.gopath": "/home/drewgonzales/docs/CS/Code/go",
-    "go.goroot": "/home/drewgonzales/usr/local/go",
+    "go.gopath": "/your/gopath",
+    "go.goroot": "/your/goroot", # or whatever /mnt/NRG/usr/local/go is set to
 }
 ```

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"regexp"
-	"strings"
 
 	"github.com/urfave/cli/v2"
 )
@@ -14,17 +12,7 @@ func ConfigCommand(c *cli.Context) error {
 		return err
 	}
 
-	stringConfig := fmt.Sprintf("%+v\n", *config)
-	re, err := regexp.Compile(`[&\{\}]`)
-	if err != nil {
-		return err
-	}
-
-	sanitizedConfig := re.ReplaceAllString(stringConfig, "")
-	listConfigs := strings.Fields(sanitizedConfig)
-	for _, l := range listConfigs {
-		fmt.Println(l)
-	}
-
+	fmt.Println(config)
+	warnOnMissingPath(config)
 	return nil
 }

--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/urfave/cli/v2"
 
@@ -32,4 +34,12 @@ func BeforeActionParseConfig(c *cli.Context) error {
 	c.Context = context.WithValue(c.Context, "config", pkg.ReadConfig())
 	pkg.Debug(fmt.Sprintf("%+v", pkg.ReadConfig()))
 	return nil
+}
+
+func warnOnMissingPath(config *pkg.Config) {
+	bin := config.GoenvRootDirectory + "/bin"
+	if path := os.Getenv("PATH"); !strings.Contains(path, bin) {
+		pkg.Info(fmt.Sprintf("%s is not in your PATH", bin))
+		pkg.Info(fmt.Sprintf("export PATH=%s:$PATH # to include it", bin))
+	}
 }

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -22,13 +22,13 @@ func InstallCommand(c *cli.Context) error {
 		return err
 	}
 
-	if err := Install(config, version); err != nil {
+	if err := install(config, version); err != nil {
 		return err
 	}
 	return nil
 }
 
-func Install(config *pkg.Config, version string) error {
+func install(config *pkg.Config, version string) error {
 	if inaccessible := pkg.CheckRW(config); len(inaccessible) > 0 {
 		return fmt.Errorf(PermError, inaccessible)
 	}
@@ -43,10 +43,10 @@ func Install(config *pkg.Config, version string) error {
 		return errors.Wrap(err, "could not download go")
 	}
 
-	err = pkg.ExtractTarGz(filePath, path.Join(config.GoenvRootDirectory, goVersion.Original()))
+	err = pkg.ExtractTarGz(filePath, path.Join(config.GoenvInstallDirectory, goVersion.Original()))
 	if err != nil {
 		return errors.Wrap(err, "could not extract go")
 	}
 
-	return Use(config, version)
+	return use(config, version)
 }

--- a/internal/cmd/uninstall.go
+++ b/internal/cmd/uninstall.go
@@ -23,13 +23,13 @@ func UninstallCommand(c *cli.Context) error {
 		return err
 	}
 
-	if err := Uninstall(config, version); err != nil {
+	if err := uninstall(config, version); err != nil {
 		return err
 	}
 	return nil
 }
 
-func Uninstall(config *pkg.Config, version string) error {
+func uninstall(config *pkg.Config, version string) error {
 	if inaccessible := pkg.CheckRW(config); len(inaccessible) > 0 {
 		return fmt.Errorf(PermError, inaccessible)
 	}

--- a/internal/pkg/config.go
+++ b/internal/pkg/config.go
@@ -1,18 +1,23 @@
 package pkg
 
-import "os"
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"text/tabwriter"
+)
 
 type Config struct {
-	// This is the directory holding multiple Go installations is.
+	// The file placed at GoenvRootDirectory is a symlink to the GoenvInstallDirectory
 	GoenvRootDirectory string
 
-	// Install directory defaults to /usr/local/go and can be configured with
+	// Install directory defaults to /usr/local/goenv and can be configured with
 	GoenvInstallDirectory string
 }
 
 const (
-	DefaultGoenvRootDirectory = "/usr/local/goenv"
-	DefaultGoInstallDirectory = "/usr/local/go"
+	DefaultGoenvRootDirectory = "/usr/local/go"
+	DefaultGoInstallDirectory = "/usr/local/goenv"
 
 	// This should also be the users GOROOT.
 	GoEnvRootDirEnvVar    = "GOENV_ROOT_DIR"
@@ -36,4 +41,27 @@ func ReadConfig() *Config {
 		rootDir,
 		installDir,
 	}
+}
+
+func (c *Config) String() string {
+	buf := bytes.Buffer{}
+	w := tabwriter.NewWriter(&buf, 0, 0, 1, ' ', 0)
+
+	rootDir := fmt.Sprintf("%s:\t%s", GoEnvRootDirEnvVar, c.GoenvRootDirectory)
+	if c.GoenvRootDirectory == DefaultGoenvRootDirectory {
+		rootDir += "\t(default)\n"
+	} else {
+		rootDir += "\t(set by environment variable)\n"
+	}
+	w.Write([]byte(rootDir))
+
+	installDir := fmt.Sprintf("%s:\t%s", GoEnvInstallDirEnvVar, c.GoenvInstallDirectory)
+	if c.GoenvInstallDirectory == DefaultGoInstallDirectory {
+		installDir += "\t(default)\n"
+	} else {
+		installDir += "\t(set by environment variable)\n"
+	}
+	w.Write([]byte(installDir))
+	w.Flush()
+	return buf.String()
 }

--- a/templates/README.md
+++ b/templates/README.md
@@ -2,11 +2,32 @@
 
 ![github workflow](https://github.com/drewgonzales360/goenv/actions/workflows/github-actions.yml/badge.svg)
 
-goenv is an small, simple binary that executes the [install instructions](https://go.dev/doc/install) on the Go website and manages several Go versions. There are several other implementations that have more features, but this has fewer ones by design. Goenv downloads and extracts go to `/usr/local/goenv/<VERSION>` and adds a symlink from `/usr/local/go -> /usr/local/goenv/<VERSION>`. It doesn't do anything fancy like guess the version of a project, intercept calls to `go`, or check for new versions.
+goenv is an small, simple binary that executes the [install instructions](https://go.dev/doc/install) on the Go website and manages several Go versions. Goenv downloads and extracts go to `/usr/local/goenv/<VERSION>` and adds a symlink from `/usr/local/go -> /usr/local/goenv/<VERSION>`. It was heavily inspired by [Dave Cheney's blog post](https://dave.cheney.net/2014/04/20/how-to-install-multiple-versions-of-go).
+
+## Install
+
+To install goenv, follow the steps below. Older releases are in the [Releases page](https://github.com/drewgonzales360/goenv/releases).
+
+```bash
+# Step 1: Linux Only
+curl -sSL https://github.com/drewgonzales360/goenv/releases/download/${SEMVER}/goenv-linux-amd64-${SEMVER}.tar.gz -o /tmp/goenv-${SEMVER}.tar.gz
+
+# Step 1: Mac Only
+curl -sSL https://github.com/drewgonzales360/goenv/releases/download/${SEMVER}/goenv-darwin-amd64-${SEMVER}.tar.gz -o /tmp/goenv-${SEMVER}.tar.gz
+
+# Step 2: Extract and Install Go
+tar -xzvf /tmp/goenv-${SEMVER}.tar.gz -C /tmp
+mv /tmp/goenv /usr/local/bin
+
+# Step 3: Add /usr/local/go/bin (or $GOENV_ROOT_DIR/bin) to PATH
+export PATH=/usr/local/go/bin:PATH
+```
+
+Install this binary _without_ `go install` so that it is managed independent of Go.
 
 ## Usage
 
-Calling `goenv` without any arguments will print out a helpful block of text, but here are a few useful examples.
+Calling `goenv` without any arguments will print out a helpful block of text, but here are a few useful examples. Note that installing 1.14 will install 1.14, even if 1.14.5 is the latest patch version.
 
 ```bash
 # Install and use a go version
@@ -22,38 +43,43 @@ goenv uninstall 1.16
 goenv list
 ```
 
-## Install
-
-To install goenv, follow the steps below. Older releases are in the Releases page.
-
-```bash
-# Step 1: Linux Only
-curl -sSL https://github.com/drewgonzales360/goenv/releases/download/${SEMVER}/goenv-linux-amd64-${SEMVER}.tar.gz -o /tmp/goenv-${SEMVER}.tar.gz
-
-# Step 1: Mac Only
-curl -sSL https://github.com/drewgonzales360/goenv/releases/download/${SEMVER}/goenv-darwin-amd64-${SEMVER}.tar.gz -o /tmp/goenv-${SEMVER}.tar.gz
-
-# Step 2: Extract and Install Go
-tar -xzvf /tmp/goenv-${SEMVER}.tar.gz -C /tmp
-mv /tmp/goenv /usr/local/bin
-
-# Step 3: Add /usr/local/go/bin to PATH or put this line in whichever dotfile is used
-export PATH=/usr/local/go/bin:PATH
-```
-
-It's best to install this binary without `go install` so that it is managed independent of Go.
-
 ## Configuration
 
 | Environment Variable  | Default             | Explanation |
 | -                     | -                   | - |
-| GOENV_ROOT_DIR        | "/usr/local/go"     | Usually equivalent to your GoRoot. This is should be in your path and links to the GOENV_INSTALL_DIR |
+| GOENV_ROOT_DIR        | "/usr/local/go"     | This is the default Go root. This is should be in your path and links to the GOENV_INSTALL_DIR |
 | GOENV_INSTALL_DIR     | "/usr/local/goenv"  | Directory where your various Go installations will be installed |
+
+The default `GOROOT` usually requires root access. You can avoid it by setting the configuration variables above. Adding
+
+```shell
+# goenv configuration
+export GOENV_INSTALL_DIR="$HOME/.local/goenv"
+export GOENV_ROOT_DIR="$HOME/.local/go"
+export PATH="$GOENV_ROOT_DIR/bin:$PATH"
+```
 
 If your VScode editor throws you weird errors on start up, add this to your vscode settings.json.
 ```json
 {
-    "go.gopath": "/home/drewgonzales/docs/CS/Code/go",
-    "go.goroot": "/home/drewgonzales/usr/local/go",
+    "go.gopath": "/your/gopath",
+    "go.goroot": "/your/goroot", # or whatever $GOENV_ROOT_DIR is set to
 }
 ```
+
+## How This Works
+
+`goenv` does the following by default:
+  - Downloads the tarball for the corresponding version a user provides. Makes a best effort attempt to check the shasums
+  - Extracts the tarball to `/usr/local/goenv/${VERSION}`. For example, `goenv install 1.17.6` will create `/usr/local/goenv/1.17.6`
+  - Creates a symlink from `/usr/local/go/` to `/usr/local/goenv/1.17.6/bin/go`. The same thing happens for `gofmt`.
+
+The install directory `/usr/local/goenv` and root directory `/usr/local/go` is configurable through environment variables.
+
+## Other Implementations
+
+There are a few other implementations of this that have more features, but I only needed the binaries. Other implementations can do fancier things like check for the correct Go version for a module and use the corresponding version in runtime, but they require intercepting the call to Go and passing the command to the right version. I didn't want my code to be in the "hot path."
+
+A few other implementations are also written in other languages. This one is written in Go 🥵.
+
+The recommendation on the Go website is to use your first install of Go to install _other_ versions of Go. Then you'd call other versions of Go like `go1.17.8 build`. This provides a consistent experience.

--- a/templates/README.md
+++ b/templates/README.md
@@ -10,13 +10,13 @@ To install goenv, follow the steps below. Older releases are in the [Releases pa
 
 ```bash
 # Step 1: Linux Only
-curl -sSL https://github.com/drewgonzales360/goenv/releases/download/${SEMVER}/goenv-linux-amd64-${SEMVER}.tar.gz -o /tmp/goenv-${SEMVER}.tar.gz
+curl -sSL https://github.com/drewgonzales360/goenv/releases/download/XXLatestXX/goenv-linux-amd64-XXLatestXX.tar.gz -o /tmp/goenv-XXLatestXX.tar.gz
 
 # Step 1: Mac Only
-curl -sSL https://github.com/drewgonzales360/goenv/releases/download/${SEMVER}/goenv-darwin-amd64-${SEMVER}.tar.gz -o /tmp/goenv-${SEMVER}.tar.gz
+curl -sSL https://github.com/drewgonzales360/goenv/releases/download/XXLatestXX/goenv-darwin-amd64-XXLatestXX.tar.gz -o /tmp/goenv-XXLatestXX.tar.gz
 
 # Step 2: Extract and Install Go
-tar -xzvf /tmp/goenv-${SEMVER}.tar.gz -C /tmp
+tar -xzvf /tmp/goenv-XXLatestXX.tar.gz -C /tmp
 mv /tmp/goenv /usr/local/bin
 
 # Step 3: Add /usr/local/go/bin (or $GOENV_ROOT_DIR/bin) to PATH


### PR DESCRIPTION
The environment variables configuring the root directory and install directory were confusing and inconsistent.

```
| GOENV_ROOT_DIR        | "/usr/local/go"     | This is the default Go root. This is should be in your path and links to the GOENV_INSTALL_DIR |
| GOENV_INSTALL_DIR     | "/usr/local/goenv"  | Directory where your various Go installations will be installed |
```

The `GOENV_ROOT_DIR` should have the same value as the `GOROOT` value. It makes things less confusing. The installation directory should have all installations of Go. 